### PR TITLE
graphql-transport-ws protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 yarn add @ilijanl/graphql-ws-graphqless
 ```
 
-A fork of graphql-ws. This package is meant to be used for custom executions based on graphql-ws protocol. If used for graphql, go with original graphql-ws package.
+A fork of graphql-ws. This package is meant to be used for custom executions based on graphql-transport-ws protocol. If used for graphql, go with original graphql-ws package.
 
 All credits go to @enisdenjo
 


### PR DESCRIPTION
The WS subprotocol is called "graphql-**transport**-ws" ([see here](https://github.com/ilijaNL/graphql-ws/blob/master/PROTOCOL.md#communication)), not to be confused with the [deprecated "graphql-ws" subprotocol from `subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md).